### PR TITLE
Use path.basename to remote asset target directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,15 +49,8 @@ class Uploader extends events.EventEmitter {
         }));
     }
 
-    _removeAssetTargetDir(file) {
-        const target = path.resolve(this.target);
-        const dirname = path.resolve(path.dirname(target));
-        const res = path.resolve(file);
-        return this.isDirectory ? res.replace(target, '') : res;
-    }
-
     _getTargetFilename(file) {
-        const shortName = this.opts.flatten ? this._removeAssetTargetDir(file) : file;
+        const shortName = this.opts.flatten ? path.basename(file) : file;
         const prefix = this.opts.prefix;
         if (!prefix) {
             return shortName;


### PR DESCRIPTION
The previous implementation left a leading path separator to the file name, resulting in the file being uploaded to en empty S3 folder if no subfolder was specified.
